### PR TITLE
Remove more Vecs, replace byteorder with std, hashing

### DIFF
--- a/src/rs/4prims.rs
+++ b/src/rs/4prims.rs
@@ -45,13 +45,15 @@ pub fn decrypt(k: [u8; DHLEN], n: u64, ad: &[u8], ciphertext: &[u8]) -> Option<V
 	}
 }
 
-pub fn hash(data: &[u8]) -> [u8; HASHLEN] {
-	let mut blake2s: Blake2s = Blake2s::new(HASHLEN);
-	blake2s.input(&data[..]);
-	let mut digest_res: [u8; HASHLEN] = EMPTY_HASH;
-	blake2s.result(&mut digest_res);
-	blake2s.reset();
-	digest_res
+pub fn hash(datas: &[&[u8]]) -> [u8; HASHLEN] {
+        let mut blake2s: Blake2s = Blake2s::new(HASHLEN);
+        for data in datas.into_iter() {
+                blake2s.input(&data[..]);
+        }
+        let mut digest_res: [u8; HASHLEN] = EMPTY_HASH;
+        blake2s.result(&mut digest_res);
+        blake2s.reset();
+        digest_res
 }
 
 pub fn hmac(key: &[u8], data: &[u8], out: &mut [u8]) {

--- a/src/rs/4prims.rs
+++ b/src/rs/4prims.rs
@@ -6,7 +6,6 @@ use crate::{
 	consts::{BLOCKLEN, DHLEN, EMPTY_HASH, HASHLEN, MAC_LENGTH, NONCE_LENGTH},
 	types::Keypair,
 };
-use byteorder::{ByteOrder, LittleEndian};
 use crypto::{blake2s::Blake2s, digest::Digest};
 use hacl_star::chacha20poly1305;
 
@@ -19,7 +18,7 @@ pub fn encrypt(k: [u8; DHLEN], n: u64, ad: &[u8], plaintext: &[u8]) -> Vec<u8> {
 	let mut mac: [u8; MAC_LENGTH] = [0u8; MAC_LENGTH];
 	let mut in_out = plaintext.to_owned();
 	let mut nonce: [u8; NONCE_LENGTH] = [0u8; NONCE_LENGTH];
-	LittleEndian::write_u64(&mut nonce[4..], n);
+    nonce[4..].copy_from_slice(&n.to_le_bytes());
 	chacha20poly1305::key(&k)
 		.nonce(&nonce)
 		.encrypt(&ad, &mut in_out[..], &mut mac);
@@ -34,7 +33,7 @@ pub fn decrypt(k: [u8; DHLEN], n: u64, ad: &[u8], ciphertext: &[u8]) -> Option<V
 	let mut mac: [u8; MAC_LENGTH] = [0u8; MAC_LENGTH];
 	mac.copy_from_slice(y);
 	let mut nonce: [u8; NONCE_LENGTH] = [0u8; NONCE_LENGTH];
-	LittleEndian::write_u64(&mut nonce[4..], n);
+    nonce[4..].copy_from_slice(&n.to_le_bytes());
 	let decryption_status =
 		chacha20poly1305::key(&k)
 			.nonce(&nonce)

--- a/src/rs/4prims.rs
+++ b/src/rs/4prims.rs
@@ -29,8 +29,7 @@ pub fn encrypt(k: [u8; DHLEN], n: u64, ad: &[u8], plaintext: &[u8]) -> Vec<u8> {
 }
 
 pub fn decrypt(k: [u8; DHLEN], n: u64, ad: &[u8], ciphertext: &[u8]) -> Option<Vec<u8>> {
-	let temp = Vec::from(ciphertext);
-	let (x, y) = temp.split_at(temp.len() - MAC_LENGTH);
+	let (x, y) = ciphertext.split_at(ciphertext.len() - MAC_LENGTH);
 	let mut in_out = x.to_owned();
 	let mut mac: [u8; MAC_LENGTH] = [0u8; MAC_LENGTH];
 	mac.copy_from_slice(y);

--- a/src/rs/5state.rs
+++ b/src/rs/5state.rs
@@ -172,8 +172,7 @@ impl SymmetricState {
 		from_slice_hashlen(&self.h.as_bytes()[..])
 	}
 	pub(crate) fn encrypt_and_hash(&mut self, plaintext: &[u8]) -> Option<Vec<u8>> {
-		let ciphertext: Vec<u8> =
-			Vec::from(&self.cs.encrypt_with_ad(&self.h.as_bytes()[..], plaintext)[..]);
+		let ciphertext: Vec<u8> = self.cs.encrypt_with_ad(&self.h.as_bytes()[..], plaintext);
 		self.mix_hash(&ciphertext);
 		Some(ciphertext)
 	}

--- a/src/rs/5state.rs
+++ b/src/rs/5state.rs
@@ -114,7 +114,7 @@ impl SymmetricState {
                 copy_slices!(protocol_name,&mut array);
                 array
         } else {
-                hash(protocol_name)
+                hash(&[protocol_name])
         });
         let ck: Hash = Hash::from_bytes(from_slice_hashlen(&h.as_bytes()[..]));
 		let cs: CipherState = CipherState::new();
@@ -138,9 +138,7 @@ impl SymmetricState {
 		self.cs = CipherState::from_key(Key::from_bytes(temp_k));
 	}
 	pub(crate) fn mix_hash(&mut self, data: &[u8]) {
-		let mut temp: Vec<u8> = Vec::from(&self.h.as_bytes()[..]);
-		temp.extend(data);
-		self.h = Hash::from_bytes(hash(&temp[..]));
+        self.h = Hash::from_bytes(hash(&[&self.h.as_bytes()[..], data]));
 	}
 	#[allow(dead_code)]
 	pub(crate) fn mix_key_and_hash(&mut self, input_key_material: &[u8]) {

--- a/src/rs/5state.rs
+++ b/src/rs/5state.rs
@@ -109,19 +109,14 @@ impl SymmetricState {
 		self.h.clear();
 	}
 	pub fn initialize_symmetric(protocol_name: &[u8]) -> SymmetricState {
-		let h: Hash;
-		match protocol_name.len() {
-			0..=31 => {
-				let mut temp = Vec::from(protocol_name);
-				while temp.len() != HASHLEN {
-					temp.push(0u8);
-				}
-				h = Hash::from_bytes(from_slice_hashlen(&temp[..]));
-			}
-			32 => h = Hash::from_bytes(from_slice_hashlen(protocol_name)),
-			_ => h = Hash::from_bytes(hash(protocol_name)),
-		}
-		let ck: Hash = Hash::from_bytes(from_slice_hashlen(&h.as_bytes()[..]));
+        let h: Hash = Hash::from_bytes(if protocol_name.len() <= 32 {
+                let mut array = [0u8; HASHLEN];
+                copy_slices!(protocol_name,&mut array);
+                array
+        } else {
+                hash(protocol_name)
+        });
+        let ck: Hash = Hash::from_bytes(from_slice_hashlen(&h.as_bytes()[..]));
 		let cs: CipherState = CipherState::new();
 		SymmetricState { cs, ck, h }
 	}

--- a/src/rs/5state.rs
+++ b/src/rs/5state.rs
@@ -169,14 +169,20 @@ impl SymmetricState {
 		self.mix_hash(&ciphertext);
 		Some(ciphertext)
 	}
+    // Do you mean to panic?
+    pub(crate) fn decrypt_and_hash(&mut self, ciphertext: &[u8]) -> Option<Vec<u8>> {
+            let plaintext = self.cs.decrypt_with_ad(&self.h.as_bytes()[..], &ciphertext).expect("Invalid ad");
+            self.mix_hash(ciphertext);
+            Some(plaintext)
+    }
+    // Or returning None what you meant?
+    /*
 	pub(crate) fn decrypt_and_hash(&mut self, ciphertext: &[u8]) -> Option<Vec<u8>> {
-		if let Some(plaintext) = self.cs.decrypt_with_ad(&self.h.as_bytes()[..], &ciphertext) {
-			self.mix_hash(ciphertext);
-			return Some(Vec::from(&plaintext[..]));
-		} else {
-			panic!("Invalid ad");
-		}
+		let plaintext = self.cs.decrypt_with_ad(&self.h.as_bytes()[..], &ciphertext) ?;
+	    self.mix_hash(ciphertext);
+		Some(plaintext)
 	}
+    */
 	pub(crate) fn split(&mut self) -> (CipherState, CipherState) {
 		let mut temp_k1: [u8; HASHLEN] = EMPTY_HASH;
 		let mut temp_k2: [u8; HASHLEN] = EMPTY_HASH;

--- a/src/rs/Cargo.toml
+++ b/src/rs/Cargo.toml
@@ -5,7 +5,6 @@ authors = ["Georgio Nicolas <georgio@symbolic.software>"]
 edition = "2018"
 
 [dependencies]
-byteorder = ">=1.3.1"
 hacl-star = ">=0.0.14"
 hex = ">=0.3.2"
 rand = ">=0.6.5"


### PR DESCRIPTION
This removes several more Vec and replaces the byte order crate with to_le_bytes() from std.  It probably will not compile because I likely made some cut & paste errors.  I'll figure out your build system tomorrow.

I "fixed" your `hash(&[u8])` the shitty way by making it a `hash(&[&[u8]])` but I'd recommend just using Digest trait methods directly in state.rs myself.  I previously suggested the blake2_rfc crate because actualy implements the rfcs more closely, but if you do want a Digest trait then the maintained fork of rust-crypto is https://docs.rs/blake2/0.8.0/blake2/trait.Digest.html

All Rust Digest traits are intelligent and obnoxious btw. 