### PR TITLE
Fixed web version inserting commas into Go code, causing syntax errors.

### DIFF
--- a/html/res/js/noiseWebIde.js
+++ b/html/res/js/noiseWebIde.js
@@ -321,7 +321,7 @@ let goGen = (patternInput, aId, autoClick) => {
 	}
 	getGo(patternInput, parsedPattern, (go) => {
 		let goBlob = window.URL.createObjectURL(
-			new Blob([go], { type: 'text/plain' })
+			new Blob([go.join('\n')], { type: 'text/plain' })
 		);
 		genReady.go = true;
 		$(aId).href = goBlob;


### PR DESCRIPTION
When downloading the Go code for IKpsk2 and KK from noiseexplorer.com today, the code would not compile due to syntax errors. For IKpsk2, this is the output of ```go build```:
```
# command-line-arguments
./IKpsk2.noise.go:33:1: syntax error: non-declaration statement outside function body
./IKpsk2.noise.go:76:1: syntax error: non-declaration statement outside function body
./IKpsk2.noise.go:92:1: syntax error: non-declaration statement outside function body
./IKpsk2.noise.go:126:2: syntax error: unexpected comma after top level declaration
./IKpsk2.noise.go:204:1: syntax error: non-declaration statement outside function body
./IKpsk2.noise.go:452:1: syntax error: non-declaration statement outside function body
``` 
The faulty Go code is attached.

This occurred in Firefox 89.0.2 and Chromium 92.0.4515.107.

[IKpsk2.noise.go.txt](https://github.com/symbolicsoft/noiseexplorer/files/6877984/IKpsk2.noise.go.txt)
