### PR TITLE
Fix authentication failure handling in decryption path of Go implementations

### DIFF
--- a/implementations/go/I1K.noise.go
+++ b/implementations/go/I1K.noise.go
@@ -242,7 +242,9 @@ func decryptWithAd(cs *cipherstate, ad []byte, ciphertext []byte) (*cipherstate,
 		return cs, []byte{}, false, err
 	}
 	valid, ad, plaintext := decrypt(cs.k, cs.n, ad, ciphertext)
-	cs = setNonce(cs, incrementNonce(cs.n))
+	if valid {
+		cs = setNonce(cs, incrementNonce(cs.n))
+	}
 	return cs, plaintext, valid, err
 }
 

--- a/implementations/go/I1K1.noise.go
+++ b/implementations/go/I1K1.noise.go
@@ -242,7 +242,9 @@ func decryptWithAd(cs *cipherstate, ad []byte, ciphertext []byte) (*cipherstate,
 		return cs, []byte{}, false, err
 	}
 	valid, ad, plaintext := decrypt(cs.k, cs.n, ad, ciphertext)
-	cs = setNonce(cs, incrementNonce(cs.n))
+	if valid {
+		cs = setNonce(cs, incrementNonce(cs.n))
+	}
 	return cs, plaintext, valid, err
 }
 

--- a/implementations/go/I1N.noise.go
+++ b/implementations/go/I1N.noise.go
@@ -240,7 +240,9 @@ func decryptWithAd(cs *cipherstate, ad []byte, ciphertext []byte) (*cipherstate,
 		return cs, []byte{}, false, err
 	}
 	valid, ad, plaintext := decrypt(cs.k, cs.n, ad, ciphertext)
-	cs = setNonce(cs, incrementNonce(cs.n))
+	if valid {
+		cs = setNonce(cs, incrementNonce(cs.n))
+	}
 	return cs, plaintext, valid, err
 }
 

--- a/implementations/go/I1X.noise.go
+++ b/implementations/go/I1X.noise.go
@@ -240,7 +240,9 @@ func decryptWithAd(cs *cipherstate, ad []byte, ciphertext []byte) (*cipherstate,
 		return cs, []byte{}, false, err
 	}
 	valid, ad, plaintext := decrypt(cs.k, cs.n, ad, ciphertext)
-	cs = setNonce(cs, incrementNonce(cs.n))
+	if valid {
+		cs = setNonce(cs, incrementNonce(cs.n))
+	}
 	return cs, plaintext, valid, err
 }
 

--- a/implementations/go/I1X1.noise.go
+++ b/implementations/go/I1X1.noise.go
@@ -240,7 +240,9 @@ func decryptWithAd(cs *cipherstate, ad []byte, ciphertext []byte) (*cipherstate,
 		return cs, []byte{}, false, err
 	}
 	valid, ad, plaintext := decrypt(cs.k, cs.n, ad, ciphertext)
-	cs = setNonce(cs, incrementNonce(cs.n))
+	if valid {
+		cs = setNonce(cs, incrementNonce(cs.n))
+	}
 	return cs, plaintext, valid, err
 }
 

--- a/implementations/go/IK.noise.go
+++ b/implementations/go/IK.noise.go
@@ -241,7 +241,9 @@ func decryptWithAd(cs *cipherstate, ad []byte, ciphertext []byte) (*cipherstate,
 		return cs, []byte{}, false, err
 	}
 	valid, ad, plaintext := decrypt(cs.k, cs.n, ad, ciphertext)
-	cs = setNonce(cs, incrementNonce(cs.n))
+	if valid {
+		cs = setNonce(cs, incrementNonce(cs.n))
+	}
 	return cs, plaintext, valid, err
 }
 

--- a/implementations/go/IK1.noise.go
+++ b/implementations/go/IK1.noise.go
@@ -242,7 +242,9 @@ func decryptWithAd(cs *cipherstate, ad []byte, ciphertext []byte) (*cipherstate,
 		return cs, []byte{}, false, err
 	}
 	valid, ad, plaintext := decrypt(cs.k, cs.n, ad, ciphertext)
-	cs = setNonce(cs, incrementNonce(cs.n))
+	if valid {
+		cs = setNonce(cs, incrementNonce(cs.n))
+	}
 	return cs, plaintext, valid, err
 }
 

--- a/implementations/go/IKpsk1.noise.go
+++ b/implementations/go/IKpsk1.noise.go
@@ -241,7 +241,9 @@ func decryptWithAd(cs *cipherstate, ad []byte, ciphertext []byte) (*cipherstate,
 		return cs, []byte{}, false, err
 	}
 	valid, ad, plaintext := decrypt(cs.k, cs.n, ad, ciphertext)
-	cs = setNonce(cs, incrementNonce(cs.n))
+	if valid {
+		cs = setNonce(cs, incrementNonce(cs.n))
+	}
 	return cs, plaintext, valid, err
 }
 

--- a/implementations/go/IKpsk2.noise.go
+++ b/implementations/go/IKpsk2.noise.go
@@ -241,7 +241,9 @@ func decryptWithAd(cs *cipherstate, ad []byte, ciphertext []byte) (*cipherstate,
 		return cs, []byte{}, false, err
 	}
 	valid, ad, plaintext := decrypt(cs.k, cs.n, ad, ciphertext)
-	cs = setNonce(cs, incrementNonce(cs.n))
+	if valid {
+		cs = setNonce(cs, incrementNonce(cs.n))
+	}
 	return cs, plaintext, valid, err
 }
 

--- a/implementations/go/IN.noise.go
+++ b/implementations/go/IN.noise.go
@@ -239,7 +239,9 @@ func decryptWithAd(cs *cipherstate, ad []byte, ciphertext []byte) (*cipherstate,
 		return cs, []byte{}, false, err
 	}
 	valid, ad, plaintext := decrypt(cs.k, cs.n, ad, ciphertext)
-	cs = setNonce(cs, incrementNonce(cs.n))
+	if valid {
+		cs = setNonce(cs, incrementNonce(cs.n))
+	}
 	return cs, plaintext, valid, err
 }
 

--- a/implementations/go/INpsk1.noise.go
+++ b/implementations/go/INpsk1.noise.go
@@ -239,7 +239,9 @@ func decryptWithAd(cs *cipherstate, ad []byte, ciphertext []byte) (*cipherstate,
 		return cs, []byte{}, false, err
 	}
 	valid, ad, plaintext := decrypt(cs.k, cs.n, ad, ciphertext)
-	cs = setNonce(cs, incrementNonce(cs.n))
+	if valid {
+		cs = setNonce(cs, incrementNonce(cs.n))
+	}
 	return cs, plaintext, valid, err
 }
 

--- a/implementations/go/INpsk2.noise.go
+++ b/implementations/go/INpsk2.noise.go
@@ -239,7 +239,9 @@ func decryptWithAd(cs *cipherstate, ad []byte, ciphertext []byte) (*cipherstate,
 		return cs, []byte{}, false, err
 	}
 	valid, ad, plaintext := decrypt(cs.k, cs.n, ad, ciphertext)
-	cs = setNonce(cs, incrementNonce(cs.n))
+	if valid {
+		cs = setNonce(cs, incrementNonce(cs.n))
+	}
 	return cs, plaintext, valid, err
 }
 

--- a/implementations/go/IX.noise.go
+++ b/implementations/go/IX.noise.go
@@ -239,7 +239,9 @@ func decryptWithAd(cs *cipherstate, ad []byte, ciphertext []byte) (*cipherstate,
 		return cs, []byte{}, false, err
 	}
 	valid, ad, plaintext := decrypt(cs.k, cs.n, ad, ciphertext)
-	cs = setNonce(cs, incrementNonce(cs.n))
+	if valid {
+		cs = setNonce(cs, incrementNonce(cs.n))
+	}
 	return cs, plaintext, valid, err
 }
 

--- a/implementations/go/IX1.noise.go
+++ b/implementations/go/IX1.noise.go
@@ -240,7 +240,9 @@ func decryptWithAd(cs *cipherstate, ad []byte, ciphertext []byte) (*cipherstate,
 		return cs, []byte{}, false, err
 	}
 	valid, ad, plaintext := decrypt(cs.k, cs.n, ad, ciphertext)
-	cs = setNonce(cs, incrementNonce(cs.n))
+	if valid {
+		cs = setNonce(cs, incrementNonce(cs.n))
+	}
 	return cs, plaintext, valid, err
 }
 

--- a/implementations/go/IXpsk2.noise.go
+++ b/implementations/go/IXpsk2.noise.go
@@ -239,7 +239,9 @@ func decryptWithAd(cs *cipherstate, ad []byte, ciphertext []byte) (*cipherstate,
 		return cs, []byte{}, false, err
 	}
 	valid, ad, plaintext := decrypt(cs.k, cs.n, ad, ciphertext)
-	cs = setNonce(cs, incrementNonce(cs.n))
+	if valid {
+		cs = setNonce(cs, incrementNonce(cs.n))
+	}
 	return cs, plaintext, valid, err
 }
 

--- a/implementations/go/K.noise.go
+++ b/implementations/go/K.noise.go
@@ -239,7 +239,9 @@ func decryptWithAd(cs *cipherstate, ad []byte, ciphertext []byte) (*cipherstate,
 		return cs, []byte{}, false, err
 	}
 	valid, ad, plaintext := decrypt(cs.k, cs.n, ad, ciphertext)
-	cs = setNonce(cs, incrementNonce(cs.n))
+	if valid {
+		cs = setNonce(cs, incrementNonce(cs.n))
+	}
 	return cs, plaintext, valid, err
 }
 

--- a/implementations/go/K1K.noise.go
+++ b/implementations/go/K1K.noise.go
@@ -243,7 +243,9 @@ func decryptWithAd(cs *cipherstate, ad []byte, ciphertext []byte) (*cipherstate,
 		return cs, []byte{}, false, err
 	}
 	valid, ad, plaintext := decrypt(cs.k, cs.n, ad, ciphertext)
-	cs = setNonce(cs, incrementNonce(cs.n))
+	if valid {
+		cs = setNonce(cs, incrementNonce(cs.n))
+	}
 	return cs, plaintext, valid, err
 }
 

--- a/implementations/go/K1K1.noise.go
+++ b/implementations/go/K1K1.noise.go
@@ -243,7 +243,9 @@ func decryptWithAd(cs *cipherstate, ad []byte, ciphertext []byte) (*cipherstate,
 		return cs, []byte{}, false, err
 	}
 	valid, ad, plaintext := decrypt(cs.k, cs.n, ad, ciphertext)
-	cs = setNonce(cs, incrementNonce(cs.n))
+	if valid {
+		cs = setNonce(cs, incrementNonce(cs.n))
+	}
 	return cs, plaintext, valid, err
 }
 

--- a/implementations/go/K1N.noise.go
+++ b/implementations/go/K1N.noise.go
@@ -242,7 +242,9 @@ func decryptWithAd(cs *cipherstate, ad []byte, ciphertext []byte) (*cipherstate,
 		return cs, []byte{}, false, err
 	}
 	valid, ad, plaintext := decrypt(cs.k, cs.n, ad, ciphertext)
-	cs = setNonce(cs, incrementNonce(cs.n))
+	if valid {
+		cs = setNonce(cs, incrementNonce(cs.n))
+	}
 	return cs, plaintext, valid, err
 }
 

--- a/implementations/go/K1X.noise.go
+++ b/implementations/go/K1X.noise.go
@@ -242,7 +242,9 @@ func decryptWithAd(cs *cipherstate, ad []byte, ciphertext []byte) (*cipherstate,
 		return cs, []byte{}, false, err
 	}
 	valid, ad, plaintext := decrypt(cs.k, cs.n, ad, ciphertext)
-	cs = setNonce(cs, incrementNonce(cs.n))
+	if valid {
+		cs = setNonce(cs, incrementNonce(cs.n))
+	}
 	return cs, plaintext, valid, err
 }
 

--- a/implementations/go/K1X1.noise.go
+++ b/implementations/go/K1X1.noise.go
@@ -242,7 +242,9 @@ func decryptWithAd(cs *cipherstate, ad []byte, ciphertext []byte) (*cipherstate,
 		return cs, []byte{}, false, err
 	}
 	valid, ad, plaintext := decrypt(cs.k, cs.n, ad, ciphertext)
-	cs = setNonce(cs, incrementNonce(cs.n))
+	if valid {
+		cs = setNonce(cs, incrementNonce(cs.n))
+	}
 	return cs, plaintext, valid, err
 }
 

--- a/implementations/go/KK.noise.go
+++ b/implementations/go/KK.noise.go
@@ -242,7 +242,9 @@ func decryptWithAd(cs *cipherstate, ad []byte, ciphertext []byte) (*cipherstate,
 		return cs, []byte{}, false, err
 	}
 	valid, ad, plaintext := decrypt(cs.k, cs.n, ad, ciphertext)
-	cs = setNonce(cs, incrementNonce(cs.n))
+	if valid {
+		cs = setNonce(cs, incrementNonce(cs.n))
+	}
 	return cs, plaintext, valid, err
 }
 

--- a/implementations/go/KK1.noise.go
+++ b/implementations/go/KK1.noise.go
@@ -242,7 +242,9 @@ func decryptWithAd(cs *cipherstate, ad []byte, ciphertext []byte) (*cipherstate,
 		return cs, []byte{}, false, err
 	}
 	valid, ad, plaintext := decrypt(cs.k, cs.n, ad, ciphertext)
-	cs = setNonce(cs, incrementNonce(cs.n))
+	if valid {
+		cs = setNonce(cs, incrementNonce(cs.n))
+	}
 	return cs, plaintext, valid, err
 }
 

--- a/implementations/go/KKpsk0.noise.go
+++ b/implementations/go/KKpsk0.noise.go
@@ -242,7 +242,9 @@ func decryptWithAd(cs *cipherstate, ad []byte, ciphertext []byte) (*cipherstate,
 		return cs, []byte{}, false, err
 	}
 	valid, ad, plaintext := decrypt(cs.k, cs.n, ad, ciphertext)
-	cs = setNonce(cs, incrementNonce(cs.n))
+	if valid {
+		cs = setNonce(cs, incrementNonce(cs.n))
+	}
 	return cs, plaintext, valid, err
 }
 

--- a/implementations/go/KKpsk2.noise.go
+++ b/implementations/go/KKpsk2.noise.go
@@ -242,7 +242,9 @@ func decryptWithAd(cs *cipherstate, ad []byte, ciphertext []byte) (*cipherstate,
 		return cs, []byte{}, false, err
 	}
 	valid, ad, plaintext := decrypt(cs.k, cs.n, ad, ciphertext)
-	cs = setNonce(cs, incrementNonce(cs.n))
+	if valid {
+		cs = setNonce(cs, incrementNonce(cs.n))
+	}
 	return cs, plaintext, valid, err
 }
 

--- a/implementations/go/KN.noise.go
+++ b/implementations/go/KN.noise.go
@@ -241,7 +241,9 @@ func decryptWithAd(cs *cipherstate, ad []byte, ciphertext []byte) (*cipherstate,
 		return cs, []byte{}, false, err
 	}
 	valid, ad, plaintext := decrypt(cs.k, cs.n, ad, ciphertext)
-	cs = setNonce(cs, incrementNonce(cs.n))
+	if valid {
+		cs = setNonce(cs, incrementNonce(cs.n))
+	}
 	return cs, plaintext, valid, err
 }
 

--- a/implementations/go/KNpsk0.noise.go
+++ b/implementations/go/KNpsk0.noise.go
@@ -241,7 +241,9 @@ func decryptWithAd(cs *cipherstate, ad []byte, ciphertext []byte) (*cipherstate,
 		return cs, []byte{}, false, err
 	}
 	valid, ad, plaintext := decrypt(cs.k, cs.n, ad, ciphertext)
-	cs = setNonce(cs, incrementNonce(cs.n))
+	if valid {
+		cs = setNonce(cs, incrementNonce(cs.n))
+	}
 	return cs, plaintext, valid, err
 }
 

--- a/implementations/go/KNpsk2.noise.go
+++ b/implementations/go/KNpsk2.noise.go
@@ -241,7 +241,9 @@ func decryptWithAd(cs *cipherstate, ad []byte, ciphertext []byte) (*cipherstate,
 		return cs, []byte{}, false, err
 	}
 	valid, ad, plaintext := decrypt(cs.k, cs.n, ad, ciphertext)
-	cs = setNonce(cs, incrementNonce(cs.n))
+	if valid {
+		cs = setNonce(cs, incrementNonce(cs.n))
+	}
 	return cs, plaintext, valid, err
 }
 

--- a/implementations/go/KX.noise.go
+++ b/implementations/go/KX.noise.go
@@ -241,7 +241,9 @@ func decryptWithAd(cs *cipherstate, ad []byte, ciphertext []byte) (*cipherstate,
 		return cs, []byte{}, false, err
 	}
 	valid, ad, plaintext := decrypt(cs.k, cs.n, ad, ciphertext)
-	cs = setNonce(cs, incrementNonce(cs.n))
+	if valid {
+		cs = setNonce(cs, incrementNonce(cs.n))
+	}
 	return cs, plaintext, valid, err
 }
 

--- a/implementations/go/KX1.noise.go
+++ b/implementations/go/KX1.noise.go
@@ -242,7 +242,9 @@ func decryptWithAd(cs *cipherstate, ad []byte, ciphertext []byte) (*cipherstate,
 		return cs, []byte{}, false, err
 	}
 	valid, ad, plaintext := decrypt(cs.k, cs.n, ad, ciphertext)
-	cs = setNonce(cs, incrementNonce(cs.n))
+	if valid {
+		cs = setNonce(cs, incrementNonce(cs.n))
+	}
 	return cs, plaintext, valid, err
 }
 

--- a/implementations/go/KXpsk2.noise.go
+++ b/implementations/go/KXpsk2.noise.go
@@ -241,7 +241,9 @@ func decryptWithAd(cs *cipherstate, ad []byte, ciphertext []byte) (*cipherstate,
 		return cs, []byte{}, false, err
 	}
 	valid, ad, plaintext := decrypt(cs.k, cs.n, ad, ciphertext)
-	cs = setNonce(cs, incrementNonce(cs.n))
+	if valid {
+		cs = setNonce(cs, incrementNonce(cs.n))
+	}
 	return cs, plaintext, valid, err
 }
 

--- a/implementations/go/Kpsk0.noise.go
+++ b/implementations/go/Kpsk0.noise.go
@@ -239,7 +239,9 @@ func decryptWithAd(cs *cipherstate, ad []byte, ciphertext []byte) (*cipherstate,
 		return cs, []byte{}, false, err
 	}
 	valid, ad, plaintext := decrypt(cs.k, cs.n, ad, ciphertext)
-	cs = setNonce(cs, incrementNonce(cs.n))
+	if valid {
+		cs = setNonce(cs, incrementNonce(cs.n))
+	}
 	return cs, plaintext, valid, err
 }
 

--- a/implementations/go/N.noise.go
+++ b/implementations/go/N.noise.go
@@ -238,7 +238,9 @@ func decryptWithAd(cs *cipherstate, ad []byte, ciphertext []byte) (*cipherstate,
 		return cs, []byte{}, false, err
 	}
 	valid, ad, plaintext := decrypt(cs.k, cs.n, ad, ciphertext)
-	cs = setNonce(cs, incrementNonce(cs.n))
+	if valid {
+		cs = setNonce(cs, incrementNonce(cs.n))
+	}
 	return cs, plaintext, valid, err
 }
 

--- a/implementations/go/NK.noise.go
+++ b/implementations/go/NK.noise.go
@@ -241,7 +241,9 @@ func decryptWithAd(cs *cipherstate, ad []byte, ciphertext []byte) (*cipherstate,
 		return cs, []byte{}, false, err
 	}
 	valid, ad, plaintext := decrypt(cs.k, cs.n, ad, ciphertext)
-	cs = setNonce(cs, incrementNonce(cs.n))
+	if valid {
+		cs = setNonce(cs, incrementNonce(cs.n))
+	}
 	return cs, plaintext, valid, err
 }
 

--- a/implementations/go/NK1.noise.go
+++ b/implementations/go/NK1.noise.go
@@ -241,7 +241,9 @@ func decryptWithAd(cs *cipherstate, ad []byte, ciphertext []byte) (*cipherstate,
 		return cs, []byte{}, false, err
 	}
 	valid, ad, plaintext := decrypt(cs.k, cs.n, ad, ciphertext)
-	cs = setNonce(cs, incrementNonce(cs.n))
+	if valid {
+		cs = setNonce(cs, incrementNonce(cs.n))
+	}
 	return cs, plaintext, valid, err
 }
 

--- a/implementations/go/NKpsk0.noise.go
+++ b/implementations/go/NKpsk0.noise.go
@@ -241,7 +241,9 @@ func decryptWithAd(cs *cipherstate, ad []byte, ciphertext []byte) (*cipherstate,
 		return cs, []byte{}, false, err
 	}
 	valid, ad, plaintext := decrypt(cs.k, cs.n, ad, ciphertext)
-	cs = setNonce(cs, incrementNonce(cs.n))
+	if valid {
+		cs = setNonce(cs, incrementNonce(cs.n))
+	}
 	return cs, plaintext, valid, err
 }
 

--- a/implementations/go/NKpsk2.noise.go
+++ b/implementations/go/NKpsk2.noise.go
@@ -241,7 +241,9 @@ func decryptWithAd(cs *cipherstate, ad []byte, ciphertext []byte) (*cipherstate,
 		return cs, []byte{}, false, err
 	}
 	valid, ad, plaintext := decrypt(cs.k, cs.n, ad, ciphertext)
-	cs = setNonce(cs, incrementNonce(cs.n))
+	if valid {
+		cs = setNonce(cs, incrementNonce(cs.n))
+	}
 	return cs, plaintext, valid, err
 }
 

--- a/implementations/go/NN.noise.go
+++ b/implementations/go/NN.noise.go
@@ -239,7 +239,9 @@ func decryptWithAd(cs *cipherstate, ad []byte, ciphertext []byte) (*cipherstate,
 		return cs, []byte{}, false, err
 	}
 	valid, ad, plaintext := decrypt(cs.k, cs.n, ad, ciphertext)
-	cs = setNonce(cs, incrementNonce(cs.n))
+	if valid {
+		cs = setNonce(cs, incrementNonce(cs.n))
+	}
 	return cs, plaintext, valid, err
 }
 

--- a/implementations/go/NNpsk0.noise.go
+++ b/implementations/go/NNpsk0.noise.go
@@ -239,7 +239,9 @@ func decryptWithAd(cs *cipherstate, ad []byte, ciphertext []byte) (*cipherstate,
 		return cs, []byte{}, false, err
 	}
 	valid, ad, plaintext := decrypt(cs.k, cs.n, ad, ciphertext)
-	cs = setNonce(cs, incrementNonce(cs.n))
+	if valid {
+		cs = setNonce(cs, incrementNonce(cs.n))
+	}
 	return cs, plaintext, valid, err
 }
 

--- a/implementations/go/NNpsk2.noise.go
+++ b/implementations/go/NNpsk2.noise.go
@@ -239,7 +239,9 @@ func decryptWithAd(cs *cipherstate, ad []byte, ciphertext []byte) (*cipherstate,
 		return cs, []byte{}, false, err
 	}
 	valid, ad, plaintext := decrypt(cs.k, cs.n, ad, ciphertext)
-	cs = setNonce(cs, incrementNonce(cs.n))
+	if valid {
+		cs = setNonce(cs, incrementNonce(cs.n))
+	}
 	return cs, plaintext, valid, err
 }
 

--- a/implementations/go/NX.noise.go
+++ b/implementations/go/NX.noise.go
@@ -239,7 +239,9 @@ func decryptWithAd(cs *cipherstate, ad []byte, ciphertext []byte) (*cipherstate,
 		return cs, []byte{}, false, err
 	}
 	valid, ad, plaintext := decrypt(cs.k, cs.n, ad, ciphertext)
-	cs = setNonce(cs, incrementNonce(cs.n))
+	if valid {
+		cs = setNonce(cs, incrementNonce(cs.n))
+	}
 	return cs, plaintext, valid, err
 }
 

--- a/implementations/go/NX1.noise.go
+++ b/implementations/go/NX1.noise.go
@@ -240,7 +240,9 @@ func decryptWithAd(cs *cipherstate, ad []byte, ciphertext []byte) (*cipherstate,
 		return cs, []byte{}, false, err
 	}
 	valid, ad, plaintext := decrypt(cs.k, cs.n, ad, ciphertext)
-	cs = setNonce(cs, incrementNonce(cs.n))
+	if valid {
+		cs = setNonce(cs, incrementNonce(cs.n))
+	}
 	return cs, plaintext, valid, err
 }
 

--- a/implementations/go/NXpsk2.noise.go
+++ b/implementations/go/NXpsk2.noise.go
@@ -239,7 +239,9 @@ func decryptWithAd(cs *cipherstate, ad []byte, ciphertext []byte) (*cipherstate,
 		return cs, []byte{}, false, err
 	}
 	valid, ad, plaintext := decrypt(cs.k, cs.n, ad, ciphertext)
-	cs = setNonce(cs, incrementNonce(cs.n))
+	if valid {
+		cs = setNonce(cs, incrementNonce(cs.n))
+	}
 	return cs, plaintext, valid, err
 }
 

--- a/implementations/go/Npsk0.noise.go
+++ b/implementations/go/Npsk0.noise.go
@@ -239,7 +239,9 @@ func decryptWithAd(cs *cipherstate, ad []byte, ciphertext []byte) (*cipherstate,
 		return cs, []byte{}, false, err
 	}
 	valid, ad, plaintext := decrypt(cs.k, cs.n, ad, ciphertext)
-	cs = setNonce(cs, incrementNonce(cs.n))
+	if valid {
+		cs = setNonce(cs, incrementNonce(cs.n))
+	}
 	return cs, plaintext, valid, err
 }
 

--- a/implementations/go/X.noise.go
+++ b/implementations/go/X.noise.go
@@ -238,7 +238,9 @@ func decryptWithAd(cs *cipherstate, ad []byte, ciphertext []byte) (*cipherstate,
 		return cs, []byte{}, false, err
 	}
 	valid, ad, plaintext := decrypt(cs.k, cs.n, ad, ciphertext)
-	cs = setNonce(cs, incrementNonce(cs.n))
+	if valid {
+		cs = setNonce(cs, incrementNonce(cs.n))
+	}
 	return cs, plaintext, valid, err
 }
 

--- a/implementations/go/X1K.noise.go
+++ b/implementations/go/X1K.noise.go
@@ -243,7 +243,9 @@ func decryptWithAd(cs *cipherstate, ad []byte, ciphertext []byte) (*cipherstate,
 		return cs, []byte{}, false, err
 	}
 	valid, ad, plaintext := decrypt(cs.k, cs.n, ad, ciphertext)
-	cs = setNonce(cs, incrementNonce(cs.n))
+	if valid {
+		cs = setNonce(cs, incrementNonce(cs.n))
+	}
 	return cs, plaintext, valid, err
 }
 

--- a/implementations/go/X1K1.noise.go
+++ b/implementations/go/X1K1.noise.go
@@ -243,7 +243,9 @@ func decryptWithAd(cs *cipherstate, ad []byte, ciphertext []byte) (*cipherstate,
 		return cs, []byte{}, false, err
 	}
 	valid, ad, plaintext := decrypt(cs.k, cs.n, ad, ciphertext)
-	cs = setNonce(cs, incrementNonce(cs.n))
+	if valid {
+		cs = setNonce(cs, incrementNonce(cs.n))
+	}
 	return cs, plaintext, valid, err
 }
 

--- a/implementations/go/X1N.noise.go
+++ b/implementations/go/X1N.noise.go
@@ -241,7 +241,9 @@ func decryptWithAd(cs *cipherstate, ad []byte, ciphertext []byte) (*cipherstate,
 		return cs, []byte{}, false, err
 	}
 	valid, ad, plaintext := decrypt(cs.k, cs.n, ad, ciphertext)
-	cs = setNonce(cs, incrementNonce(cs.n))
+	if valid {
+		cs = setNonce(cs, incrementNonce(cs.n))
+	}
 	return cs, plaintext, valid, err
 }
 

--- a/implementations/go/X1X.noise.go
+++ b/implementations/go/X1X.noise.go
@@ -241,7 +241,9 @@ func decryptWithAd(cs *cipherstate, ad []byte, ciphertext []byte) (*cipherstate,
 		return cs, []byte{}, false, err
 	}
 	valid, ad, plaintext := decrypt(cs.k, cs.n, ad, ciphertext)
-	cs = setNonce(cs, incrementNonce(cs.n))
+	if valid {
+		cs = setNonce(cs, incrementNonce(cs.n))
+	}
 	return cs, plaintext, valid, err
 }
 

--- a/implementations/go/X1X1.noise.go
+++ b/implementations/go/X1X1.noise.go
@@ -241,7 +241,9 @@ func decryptWithAd(cs *cipherstate, ad []byte, ciphertext []byte) (*cipherstate,
 		return cs, []byte{}, false, err
 	}
 	valid, ad, plaintext := decrypt(cs.k, cs.n, ad, ciphertext)
-	cs = setNonce(cs, incrementNonce(cs.n))
+	if valid {
+		cs = setNonce(cs, incrementNonce(cs.n))
+	}
 	return cs, plaintext, valid, err
 }
 

--- a/implementations/go/XK.noise.go
+++ b/implementations/go/XK.noise.go
@@ -242,7 +242,9 @@ func decryptWithAd(cs *cipherstate, ad []byte, ciphertext []byte) (*cipherstate,
 		return cs, []byte{}, false, err
 	}
 	valid, ad, plaintext := decrypt(cs.k, cs.n, ad, ciphertext)
-	cs = setNonce(cs, incrementNonce(cs.n))
+	if valid {
+		cs = setNonce(cs, incrementNonce(cs.n))
+	}
 	return cs, plaintext, valid, err
 }
 

--- a/implementations/go/XK1.noise.go
+++ b/implementations/go/XK1.noise.go
@@ -242,7 +242,9 @@ func decryptWithAd(cs *cipherstate, ad []byte, ciphertext []byte) (*cipherstate,
 		return cs, []byte{}, false, err
 	}
 	valid, ad, plaintext := decrypt(cs.k, cs.n, ad, ciphertext)
-	cs = setNonce(cs, incrementNonce(cs.n))
+	if valid {
+		cs = setNonce(cs, incrementNonce(cs.n))
+	}
 	return cs, plaintext, valid, err
 }
 

--- a/implementations/go/XKpsk3.noise.go
+++ b/implementations/go/XKpsk3.noise.go
@@ -242,7 +242,9 @@ func decryptWithAd(cs *cipherstate, ad []byte, ciphertext []byte) (*cipherstate,
 		return cs, []byte{}, false, err
 	}
 	valid, ad, plaintext := decrypt(cs.k, cs.n, ad, ciphertext)
-	cs = setNonce(cs, incrementNonce(cs.n))
+	if valid {
+		cs = setNonce(cs, incrementNonce(cs.n))
+	}
 	return cs, plaintext, valid, err
 }
 

--- a/implementations/go/XN.noise.go
+++ b/implementations/go/XN.noise.go
@@ -240,7 +240,9 @@ func decryptWithAd(cs *cipherstate, ad []byte, ciphertext []byte) (*cipherstate,
 		return cs, []byte{}, false, err
 	}
 	valid, ad, plaintext := decrypt(cs.k, cs.n, ad, ciphertext)
-	cs = setNonce(cs, incrementNonce(cs.n))
+	if valid {
+		cs = setNonce(cs, incrementNonce(cs.n))
+	}
 	return cs, plaintext, valid, err
 }
 

--- a/implementations/go/XNpsk3.noise.go
+++ b/implementations/go/XNpsk3.noise.go
@@ -240,7 +240,9 @@ func decryptWithAd(cs *cipherstate, ad []byte, ciphertext []byte) (*cipherstate,
 		return cs, []byte{}, false, err
 	}
 	valid, ad, plaintext := decrypt(cs.k, cs.n, ad, ciphertext)
-	cs = setNonce(cs, incrementNonce(cs.n))
+	if valid {
+		cs = setNonce(cs, incrementNonce(cs.n))
+	}
 	return cs, plaintext, valid, err
 }
 

--- a/implementations/go/XX.noise.go
+++ b/implementations/go/XX.noise.go
@@ -240,7 +240,9 @@ func decryptWithAd(cs *cipherstate, ad []byte, ciphertext []byte) (*cipherstate,
 		return cs, []byte{}, false, err
 	}
 	valid, ad, plaintext := decrypt(cs.k, cs.n, ad, ciphertext)
-	cs = setNonce(cs, incrementNonce(cs.n))
+	if valid {
+		cs = setNonce(cs, incrementNonce(cs.n))
+	}
 	return cs, plaintext, valid, err
 }
 

--- a/implementations/go/XX1.noise.go
+++ b/implementations/go/XX1.noise.go
@@ -240,7 +240,9 @@ func decryptWithAd(cs *cipherstate, ad []byte, ciphertext []byte) (*cipherstate,
 		return cs, []byte{}, false, err
 	}
 	valid, ad, plaintext := decrypt(cs.k, cs.n, ad, ciphertext)
-	cs = setNonce(cs, incrementNonce(cs.n))
+	if valid {
+		cs = setNonce(cs, incrementNonce(cs.n))
+	}
 	return cs, plaintext, valid, err
 }
 

--- a/implementations/go/XXpsk3.noise.go
+++ b/implementations/go/XXpsk3.noise.go
@@ -240,7 +240,9 @@ func decryptWithAd(cs *cipherstate, ad []byte, ciphertext []byte) (*cipherstate,
 		return cs, []byte{}, false, err
 	}
 	valid, ad, plaintext := decrypt(cs.k, cs.n, ad, ciphertext)
-	cs = setNonce(cs, incrementNonce(cs.n))
+	if valid {
+		cs = setNonce(cs, incrementNonce(cs.n))
+	}
 	return cs, plaintext, valid, err
 }
 

--- a/implementations/go/Xpsk1.noise.go
+++ b/implementations/go/Xpsk1.noise.go
@@ -239,7 +239,9 @@ func decryptWithAd(cs *cipherstate, ad []byte, ciphertext []byte) (*cipherstate,
 		return cs, []byte{}, false, err
 	}
 	valid, ad, plaintext := decrypt(cs.k, cs.n, ad, ciphertext)
-	cs = setNonce(cs, incrementNonce(cs.n))
+	if valid {
+		cs = setNonce(cs, incrementNonce(cs.n))
+	}
 	return cs, plaintext, valid, err
 }
 

--- a/implementations/go/tests/I1K/I1K.noise.go
+++ b/implementations/go/tests/I1K/I1K.noise.go
@@ -243,7 +243,9 @@ func decryptWithAd(cs *cipherstate, ad []byte, ciphertext []byte) (*cipherstate,
 		return cs, []byte{}, false, err
 	}
 	valid, ad, plaintext := decrypt(cs.k, cs.n, ad, ciphertext)
-	cs = setNonce(cs, incrementNonce(cs.n))
+	if valid {
+		cs = setNonce(cs, incrementNonce(cs.n))
+	}
 	return cs, plaintext, valid, err
 }
 

--- a/implementations/go/tests/I1K1/I1K1.noise.go
+++ b/implementations/go/tests/I1K1/I1K1.noise.go
@@ -243,7 +243,9 @@ func decryptWithAd(cs *cipherstate, ad []byte, ciphertext []byte) (*cipherstate,
 		return cs, []byte{}, false, err
 	}
 	valid, ad, plaintext := decrypt(cs.k, cs.n, ad, ciphertext)
-	cs = setNonce(cs, incrementNonce(cs.n))
+	if valid {
+		cs = setNonce(cs, incrementNonce(cs.n))
+	}
 	return cs, plaintext, valid, err
 }
 

--- a/implementations/go/tests/I1N/I1N.noise.go
+++ b/implementations/go/tests/I1N/I1N.noise.go
@@ -241,7 +241,9 @@ func decryptWithAd(cs *cipherstate, ad []byte, ciphertext []byte) (*cipherstate,
 		return cs, []byte{}, false, err
 	}
 	valid, ad, plaintext := decrypt(cs.k, cs.n, ad, ciphertext)
-	cs = setNonce(cs, incrementNonce(cs.n))
+	if valid {
+		cs = setNonce(cs, incrementNonce(cs.n))
+	}
 	return cs, plaintext, valid, err
 }
 

--- a/implementations/go/tests/I1X/I1X.noise.go
+++ b/implementations/go/tests/I1X/I1X.noise.go
@@ -241,7 +241,9 @@ func decryptWithAd(cs *cipherstate, ad []byte, ciphertext []byte) (*cipherstate,
 		return cs, []byte{}, false, err
 	}
 	valid, ad, plaintext := decrypt(cs.k, cs.n, ad, ciphertext)
-	cs = setNonce(cs, incrementNonce(cs.n))
+	if valid {
+		cs = setNonce(cs, incrementNonce(cs.n))
+	}
 	return cs, plaintext, valid, err
 }
 

--- a/implementations/go/tests/I1X1/I1X1.noise.go
+++ b/implementations/go/tests/I1X1/I1X1.noise.go
@@ -241,7 +241,9 @@ func decryptWithAd(cs *cipherstate, ad []byte, ciphertext []byte) (*cipherstate,
 		return cs, []byte{}, false, err
 	}
 	valid, ad, plaintext := decrypt(cs.k, cs.n, ad, ciphertext)
-	cs = setNonce(cs, incrementNonce(cs.n))
+	if valid {
+		cs = setNonce(cs, incrementNonce(cs.n))
+	}
 	return cs, plaintext, valid, err
 }
 

--- a/implementations/go/tests/IK/IK.noise.go
+++ b/implementations/go/tests/IK/IK.noise.go
@@ -242,7 +242,9 @@ func decryptWithAd(cs *cipherstate, ad []byte, ciphertext []byte) (*cipherstate,
 		return cs, []byte{}, false, err
 	}
 	valid, ad, plaintext := decrypt(cs.k, cs.n, ad, ciphertext)
-	cs = setNonce(cs, incrementNonce(cs.n))
+	if valid {
+		cs = setNonce(cs, incrementNonce(cs.n))
+	}
 	return cs, plaintext, valid, err
 }
 

--- a/implementations/go/tests/IK1/IK1.noise.go
+++ b/implementations/go/tests/IK1/IK1.noise.go
@@ -243,7 +243,9 @@ func decryptWithAd(cs *cipherstate, ad []byte, ciphertext []byte) (*cipherstate,
 		return cs, []byte{}, false, err
 	}
 	valid, ad, plaintext := decrypt(cs.k, cs.n, ad, ciphertext)
-	cs = setNonce(cs, incrementNonce(cs.n))
+	if valid {
+		cs = setNonce(cs, incrementNonce(cs.n))
+	}
 	return cs, plaintext, valid, err
 }
 

--- a/implementations/go/tests/IKpsk1/IKpsk1.noise.go
+++ b/implementations/go/tests/IKpsk1/IKpsk1.noise.go
@@ -242,7 +242,9 @@ func decryptWithAd(cs *cipherstate, ad []byte, ciphertext []byte) (*cipherstate,
 		return cs, []byte{}, false, err
 	}
 	valid, ad, plaintext := decrypt(cs.k, cs.n, ad, ciphertext)
-	cs = setNonce(cs, incrementNonce(cs.n))
+	if valid {
+		cs = setNonce(cs, incrementNonce(cs.n))
+	}
 	return cs, plaintext, valid, err
 }
 

--- a/implementations/go/tests/IKpsk2/IKpsk2.noise.go
+++ b/implementations/go/tests/IKpsk2/IKpsk2.noise.go
@@ -242,7 +242,9 @@ func decryptWithAd(cs *cipherstate, ad []byte, ciphertext []byte) (*cipherstate,
 		return cs, []byte{}, false, err
 	}
 	valid, ad, plaintext := decrypt(cs.k, cs.n, ad, ciphertext)
-	cs = setNonce(cs, incrementNonce(cs.n))
+	if valid {
+		cs = setNonce(cs, incrementNonce(cs.n))
+	}
 	return cs, plaintext, valid, err
 }
 

--- a/implementations/go/tests/IN/IN.noise.go
+++ b/implementations/go/tests/IN/IN.noise.go
@@ -240,7 +240,9 @@ func decryptWithAd(cs *cipherstate, ad []byte, ciphertext []byte) (*cipherstate,
 		return cs, []byte{}, false, err
 	}
 	valid, ad, plaintext := decrypt(cs.k, cs.n, ad, ciphertext)
-	cs = setNonce(cs, incrementNonce(cs.n))
+	if valid {
+		cs = setNonce(cs, incrementNonce(cs.n))
+	}
 	return cs, plaintext, valid, err
 }
 

--- a/implementations/go/tests/INpsk1/INpsk1.noise.go
+++ b/implementations/go/tests/INpsk1/INpsk1.noise.go
@@ -240,7 +240,9 @@ func decryptWithAd(cs *cipherstate, ad []byte, ciphertext []byte) (*cipherstate,
 		return cs, []byte{}, false, err
 	}
 	valid, ad, plaintext := decrypt(cs.k, cs.n, ad, ciphertext)
-	cs = setNonce(cs, incrementNonce(cs.n))
+	if valid {
+		cs = setNonce(cs, incrementNonce(cs.n))
+	}
 	return cs, plaintext, valid, err
 }
 

--- a/implementations/go/tests/INpsk2/INpsk2.noise.go
+++ b/implementations/go/tests/INpsk2/INpsk2.noise.go
@@ -240,7 +240,9 @@ func decryptWithAd(cs *cipherstate, ad []byte, ciphertext []byte) (*cipherstate,
 		return cs, []byte{}, false, err
 	}
 	valid, ad, plaintext := decrypt(cs.k, cs.n, ad, ciphertext)
-	cs = setNonce(cs, incrementNonce(cs.n))
+	if valid {
+		cs = setNonce(cs, incrementNonce(cs.n))
+	}
 	return cs, plaintext, valid, err
 }
 

--- a/implementations/go/tests/IX/IX.noise.go
+++ b/implementations/go/tests/IX/IX.noise.go
@@ -240,7 +240,9 @@ func decryptWithAd(cs *cipherstate, ad []byte, ciphertext []byte) (*cipherstate,
 		return cs, []byte{}, false, err
 	}
 	valid, ad, plaintext := decrypt(cs.k, cs.n, ad, ciphertext)
-	cs = setNonce(cs, incrementNonce(cs.n))
+	if valid {
+		cs = setNonce(cs, incrementNonce(cs.n))
+	}
 	return cs, plaintext, valid, err
 }
 

--- a/implementations/go/tests/IX1/IX1.noise.go
+++ b/implementations/go/tests/IX1/IX1.noise.go
@@ -241,7 +241,9 @@ func decryptWithAd(cs *cipherstate, ad []byte, ciphertext []byte) (*cipherstate,
 		return cs, []byte{}, false, err
 	}
 	valid, ad, plaintext := decrypt(cs.k, cs.n, ad, ciphertext)
-	cs = setNonce(cs, incrementNonce(cs.n))
+	if valid {
+		cs = setNonce(cs, incrementNonce(cs.n))
+	}
 	return cs, plaintext, valid, err
 }
 

--- a/implementations/go/tests/IXpsk2/IXpsk2.noise.go
+++ b/implementations/go/tests/IXpsk2/IXpsk2.noise.go
@@ -240,7 +240,9 @@ func decryptWithAd(cs *cipherstate, ad []byte, ciphertext []byte) (*cipherstate,
 		return cs, []byte{}, false, err
 	}
 	valid, ad, plaintext := decrypt(cs.k, cs.n, ad, ciphertext)
-	cs = setNonce(cs, incrementNonce(cs.n))
+	if valid {
+		cs = setNonce(cs, incrementNonce(cs.n))
+	}
 	return cs, plaintext, valid, err
 }
 

--- a/implementations/go/tests/K/K.noise.go
+++ b/implementations/go/tests/K/K.noise.go
@@ -240,7 +240,9 @@ func decryptWithAd(cs *cipherstate, ad []byte, ciphertext []byte) (*cipherstate,
 		return cs, []byte{}, false, err
 	}
 	valid, ad, plaintext := decrypt(cs.k, cs.n, ad, ciphertext)
-	cs = setNonce(cs, incrementNonce(cs.n))
+	if valid {
+		cs = setNonce(cs, incrementNonce(cs.n))
+	}
 	return cs, plaintext, valid, err
 }
 

--- a/implementations/go/tests/K1K/K1K.noise.go
+++ b/implementations/go/tests/K1K/K1K.noise.go
@@ -244,7 +244,9 @@ func decryptWithAd(cs *cipherstate, ad []byte, ciphertext []byte) (*cipherstate,
 		return cs, []byte{}, false, err
 	}
 	valid, ad, plaintext := decrypt(cs.k, cs.n, ad, ciphertext)
-	cs = setNonce(cs, incrementNonce(cs.n))
+	if valid {
+		cs = setNonce(cs, incrementNonce(cs.n))
+	}
 	return cs, plaintext, valid, err
 }
 

--- a/implementations/go/tests/K1K1/K1K1.noise.go
+++ b/implementations/go/tests/K1K1/K1K1.noise.go
@@ -244,7 +244,9 @@ func decryptWithAd(cs *cipherstate, ad []byte, ciphertext []byte) (*cipherstate,
 		return cs, []byte{}, false, err
 	}
 	valid, ad, plaintext := decrypt(cs.k, cs.n, ad, ciphertext)
-	cs = setNonce(cs, incrementNonce(cs.n))
+	if valid {
+		cs = setNonce(cs, incrementNonce(cs.n))
+	}
 	return cs, plaintext, valid, err
 }
 

--- a/implementations/go/tests/K1N/K1N.noise.go
+++ b/implementations/go/tests/K1N/K1N.noise.go
@@ -243,7 +243,9 @@ func decryptWithAd(cs *cipherstate, ad []byte, ciphertext []byte) (*cipherstate,
 		return cs, []byte{}, false, err
 	}
 	valid, ad, plaintext := decrypt(cs.k, cs.n, ad, ciphertext)
-	cs = setNonce(cs, incrementNonce(cs.n))
+	if valid {
+		cs = setNonce(cs, incrementNonce(cs.n))
+	}
 	return cs, plaintext, valid, err
 }
 

--- a/implementations/go/tests/K1X/K1X.noise.go
+++ b/implementations/go/tests/K1X/K1X.noise.go
@@ -243,7 +243,9 @@ func decryptWithAd(cs *cipherstate, ad []byte, ciphertext []byte) (*cipherstate,
 		return cs, []byte{}, false, err
 	}
 	valid, ad, plaintext := decrypt(cs.k, cs.n, ad, ciphertext)
-	cs = setNonce(cs, incrementNonce(cs.n))
+	if valid {
+		cs = setNonce(cs, incrementNonce(cs.n))
+	}
 	return cs, plaintext, valid, err
 }
 

--- a/implementations/go/tests/K1X1/K1X1.noise.go
+++ b/implementations/go/tests/K1X1/K1X1.noise.go
@@ -243,7 +243,9 @@ func decryptWithAd(cs *cipherstate, ad []byte, ciphertext []byte) (*cipherstate,
 		return cs, []byte{}, false, err
 	}
 	valid, ad, plaintext := decrypt(cs.k, cs.n, ad, ciphertext)
-	cs = setNonce(cs, incrementNonce(cs.n))
+	if valid {
+		cs = setNonce(cs, incrementNonce(cs.n))
+	}
 	return cs, plaintext, valid, err
 }
 

--- a/implementations/go/tests/KK/KK.noise.go
+++ b/implementations/go/tests/KK/KK.noise.go
@@ -243,7 +243,9 @@ func decryptWithAd(cs *cipherstate, ad []byte, ciphertext []byte) (*cipherstate,
 		return cs, []byte{}, false, err
 	}
 	valid, ad, plaintext := decrypt(cs.k, cs.n, ad, ciphertext)
-	cs = setNonce(cs, incrementNonce(cs.n))
+	if valid {
+		cs = setNonce(cs, incrementNonce(cs.n))
+	}
 	return cs, plaintext, valid, err
 }
 

--- a/implementations/go/tests/KK1/KK1.noise.go
+++ b/implementations/go/tests/KK1/KK1.noise.go
@@ -243,7 +243,9 @@ func decryptWithAd(cs *cipherstate, ad []byte, ciphertext []byte) (*cipherstate,
 		return cs, []byte{}, false, err
 	}
 	valid, ad, plaintext := decrypt(cs.k, cs.n, ad, ciphertext)
-	cs = setNonce(cs, incrementNonce(cs.n))
+	if valid {
+		cs = setNonce(cs, incrementNonce(cs.n))
+	}
 	return cs, plaintext, valid, err
 }
 

--- a/implementations/go/tests/KKpsk0/KKpsk0.noise.go
+++ b/implementations/go/tests/KKpsk0/KKpsk0.noise.go
@@ -243,7 +243,9 @@ func decryptWithAd(cs *cipherstate, ad []byte, ciphertext []byte) (*cipherstate,
 		return cs, []byte{}, false, err
 	}
 	valid, ad, plaintext := decrypt(cs.k, cs.n, ad, ciphertext)
-	cs = setNonce(cs, incrementNonce(cs.n))
+	if valid {
+		cs = setNonce(cs, incrementNonce(cs.n))
+	}
 	return cs, plaintext, valid, err
 }
 

--- a/implementations/go/tests/KKpsk2/KKpsk2.noise.go
+++ b/implementations/go/tests/KKpsk2/KKpsk2.noise.go
@@ -243,7 +243,9 @@ func decryptWithAd(cs *cipherstate, ad []byte, ciphertext []byte) (*cipherstate,
 		return cs, []byte{}, false, err
 	}
 	valid, ad, plaintext := decrypt(cs.k, cs.n, ad, ciphertext)
-	cs = setNonce(cs, incrementNonce(cs.n))
+	if valid {
+		cs = setNonce(cs, incrementNonce(cs.n))
+	}
 	return cs, plaintext, valid, err
 }
 

--- a/implementations/go/tests/KN/KN.noise.go
+++ b/implementations/go/tests/KN/KN.noise.go
@@ -242,7 +242,9 @@ func decryptWithAd(cs *cipherstate, ad []byte, ciphertext []byte) (*cipherstate,
 		return cs, []byte{}, false, err
 	}
 	valid, ad, plaintext := decrypt(cs.k, cs.n, ad, ciphertext)
-	cs = setNonce(cs, incrementNonce(cs.n))
+	if valid {
+		cs = setNonce(cs, incrementNonce(cs.n))
+	}
 	return cs, plaintext, valid, err
 }
 

--- a/implementations/go/tests/KNpsk0/KNpsk0.noise.go
+++ b/implementations/go/tests/KNpsk0/KNpsk0.noise.go
@@ -242,7 +242,9 @@ func decryptWithAd(cs *cipherstate, ad []byte, ciphertext []byte) (*cipherstate,
 		return cs, []byte{}, false, err
 	}
 	valid, ad, plaintext := decrypt(cs.k, cs.n, ad, ciphertext)
-	cs = setNonce(cs, incrementNonce(cs.n))
+	if valid {
+		cs = setNonce(cs, incrementNonce(cs.n))
+	}
 	return cs, plaintext, valid, err
 }
 

--- a/implementations/go/tests/KNpsk2/KNpsk2.noise.go
+++ b/implementations/go/tests/KNpsk2/KNpsk2.noise.go
@@ -242,7 +242,9 @@ func decryptWithAd(cs *cipherstate, ad []byte, ciphertext []byte) (*cipherstate,
 		return cs, []byte{}, false, err
 	}
 	valid, ad, plaintext := decrypt(cs.k, cs.n, ad, ciphertext)
-	cs = setNonce(cs, incrementNonce(cs.n))
+	if valid {
+		cs = setNonce(cs, incrementNonce(cs.n))
+	}
 	return cs, plaintext, valid, err
 }
 

--- a/implementations/go/tests/KX/KX.noise.go
+++ b/implementations/go/tests/KX/KX.noise.go
@@ -242,7 +242,9 @@ func decryptWithAd(cs *cipherstate, ad []byte, ciphertext []byte) (*cipherstate,
 		return cs, []byte{}, false, err
 	}
 	valid, ad, plaintext := decrypt(cs.k, cs.n, ad, ciphertext)
-	cs = setNonce(cs, incrementNonce(cs.n))
+	if valid {
+		cs = setNonce(cs, incrementNonce(cs.n))
+	}
 	return cs, plaintext, valid, err
 }
 

--- a/implementations/go/tests/KX1/KX1.noise.go
+++ b/implementations/go/tests/KX1/KX1.noise.go
@@ -243,7 +243,9 @@ func decryptWithAd(cs *cipherstate, ad []byte, ciphertext []byte) (*cipherstate,
 		return cs, []byte{}, false, err
 	}
 	valid, ad, plaintext := decrypt(cs.k, cs.n, ad, ciphertext)
-	cs = setNonce(cs, incrementNonce(cs.n))
+	if valid {
+		cs = setNonce(cs, incrementNonce(cs.n))
+	}
 	return cs, plaintext, valid, err
 }
 

--- a/implementations/go/tests/KXpsk2/KXpsk2.noise.go
+++ b/implementations/go/tests/KXpsk2/KXpsk2.noise.go
@@ -242,7 +242,9 @@ func decryptWithAd(cs *cipherstate, ad []byte, ciphertext []byte) (*cipherstate,
 		return cs, []byte{}, false, err
 	}
 	valid, ad, plaintext := decrypt(cs.k, cs.n, ad, ciphertext)
-	cs = setNonce(cs, incrementNonce(cs.n))
+	if valid {
+		cs = setNonce(cs, incrementNonce(cs.n))
+	}
 	return cs, plaintext, valid, err
 }
 

--- a/implementations/go/tests/Kpsk0/Kpsk0.noise.go
+++ b/implementations/go/tests/Kpsk0/Kpsk0.noise.go
@@ -240,7 +240,9 @@ func decryptWithAd(cs *cipherstate, ad []byte, ciphertext []byte) (*cipherstate,
 		return cs, []byte{}, false, err
 	}
 	valid, ad, plaintext := decrypt(cs.k, cs.n, ad, ciphertext)
-	cs = setNonce(cs, incrementNonce(cs.n))
+	if valid {
+		cs = setNonce(cs, incrementNonce(cs.n))
+	}
 	return cs, plaintext, valid, err
 }
 

--- a/implementations/go/tests/N/N.noise.go
+++ b/implementations/go/tests/N/N.noise.go
@@ -239,7 +239,9 @@ func decryptWithAd(cs *cipherstate, ad []byte, ciphertext []byte) (*cipherstate,
 		return cs, []byte{}, false, err
 	}
 	valid, ad, plaintext := decrypt(cs.k, cs.n, ad, ciphertext)
-	cs = setNonce(cs, incrementNonce(cs.n))
+	if valid {
+		cs = setNonce(cs, incrementNonce(cs.n))
+	}
 	return cs, plaintext, valid, err
 }
 

--- a/implementations/go/tests/NK/NK.noise.go
+++ b/implementations/go/tests/NK/NK.noise.go
@@ -242,7 +242,9 @@ func decryptWithAd(cs *cipherstate, ad []byte, ciphertext []byte) (*cipherstate,
 		return cs, []byte{}, false, err
 	}
 	valid, ad, plaintext := decrypt(cs.k, cs.n, ad, ciphertext)
-	cs = setNonce(cs, incrementNonce(cs.n))
+	if valid {
+		cs = setNonce(cs, incrementNonce(cs.n))
+	}
 	return cs, plaintext, valid, err
 }
 

--- a/implementations/go/tests/NK1/NK1.noise.go
+++ b/implementations/go/tests/NK1/NK1.noise.go
@@ -242,7 +242,9 @@ func decryptWithAd(cs *cipherstate, ad []byte, ciphertext []byte) (*cipherstate,
 		return cs, []byte{}, false, err
 	}
 	valid, ad, plaintext := decrypt(cs.k, cs.n, ad, ciphertext)
-	cs = setNonce(cs, incrementNonce(cs.n))
+	if valid {
+		cs = setNonce(cs, incrementNonce(cs.n))
+	}
 	return cs, plaintext, valid, err
 }
 

--- a/implementations/go/tests/NKpsk0/NKpsk0.noise.go
+++ b/implementations/go/tests/NKpsk0/NKpsk0.noise.go
@@ -242,7 +242,9 @@ func decryptWithAd(cs *cipherstate, ad []byte, ciphertext []byte) (*cipherstate,
 		return cs, []byte{}, false, err
 	}
 	valid, ad, plaintext := decrypt(cs.k, cs.n, ad, ciphertext)
-	cs = setNonce(cs, incrementNonce(cs.n))
+	if valid {
+		cs = setNonce(cs, incrementNonce(cs.n))
+	}
 	return cs, plaintext, valid, err
 }
 

--- a/implementations/go/tests/NKpsk2/NKpsk2.noise.go
+++ b/implementations/go/tests/NKpsk2/NKpsk2.noise.go
@@ -242,7 +242,9 @@ func decryptWithAd(cs *cipherstate, ad []byte, ciphertext []byte) (*cipherstate,
 		return cs, []byte{}, false, err
 	}
 	valid, ad, plaintext := decrypt(cs.k, cs.n, ad, ciphertext)
-	cs = setNonce(cs, incrementNonce(cs.n))
+	if valid {
+		cs = setNonce(cs, incrementNonce(cs.n))
+	}
 	return cs, plaintext, valid, err
 }
 

--- a/implementations/go/tests/NN/NN.noise.go
+++ b/implementations/go/tests/NN/NN.noise.go
@@ -240,7 +240,9 @@ func decryptWithAd(cs *cipherstate, ad []byte, ciphertext []byte) (*cipherstate,
 		return cs, []byte{}, false, err
 	}
 	valid, ad, plaintext := decrypt(cs.k, cs.n, ad, ciphertext)
-	cs = setNonce(cs, incrementNonce(cs.n))
+	if valid {
+		cs = setNonce(cs, incrementNonce(cs.n))
+	}
 	return cs, plaintext, valid, err
 }
 

--- a/implementations/go/tests/NNpsk0/NNpsk0.noise.go
+++ b/implementations/go/tests/NNpsk0/NNpsk0.noise.go
@@ -240,7 +240,9 @@ func decryptWithAd(cs *cipherstate, ad []byte, ciphertext []byte) (*cipherstate,
 		return cs, []byte{}, false, err
 	}
 	valid, ad, plaintext := decrypt(cs.k, cs.n, ad, ciphertext)
-	cs = setNonce(cs, incrementNonce(cs.n))
+	if valid {
+		cs = setNonce(cs, incrementNonce(cs.n))
+	}
 	return cs, plaintext, valid, err
 }
 

--- a/implementations/go/tests/NNpsk2/NNpsk2.noise.go
+++ b/implementations/go/tests/NNpsk2/NNpsk2.noise.go
@@ -240,7 +240,9 @@ func decryptWithAd(cs *cipherstate, ad []byte, ciphertext []byte) (*cipherstate,
 		return cs, []byte{}, false, err
 	}
 	valid, ad, plaintext := decrypt(cs.k, cs.n, ad, ciphertext)
-	cs = setNonce(cs, incrementNonce(cs.n))
+	if valid {
+		cs = setNonce(cs, incrementNonce(cs.n))
+	}
 	return cs, plaintext, valid, err
 }
 

--- a/implementations/go/tests/NX/NX.noise.go
+++ b/implementations/go/tests/NX/NX.noise.go
@@ -240,7 +240,9 @@ func decryptWithAd(cs *cipherstate, ad []byte, ciphertext []byte) (*cipherstate,
 		return cs, []byte{}, false, err
 	}
 	valid, ad, plaintext := decrypt(cs.k, cs.n, ad, ciphertext)
-	cs = setNonce(cs, incrementNonce(cs.n))
+	if valid {
+		cs = setNonce(cs, incrementNonce(cs.n))
+	}
 	return cs, plaintext, valid, err
 }
 

--- a/implementations/go/tests/NX1/NX1.noise.go
+++ b/implementations/go/tests/NX1/NX1.noise.go
@@ -241,7 +241,9 @@ func decryptWithAd(cs *cipherstate, ad []byte, ciphertext []byte) (*cipherstate,
 		return cs, []byte{}, false, err
 	}
 	valid, ad, plaintext := decrypt(cs.k, cs.n, ad, ciphertext)
-	cs = setNonce(cs, incrementNonce(cs.n))
+	if valid {
+		cs = setNonce(cs, incrementNonce(cs.n))
+	}
 	return cs, plaintext, valid, err
 }
 

--- a/implementations/go/tests/NXpsk2/NXpsk2.noise.go
+++ b/implementations/go/tests/NXpsk2/NXpsk2.noise.go
@@ -240,7 +240,9 @@ func decryptWithAd(cs *cipherstate, ad []byte, ciphertext []byte) (*cipherstate,
 		return cs, []byte{}, false, err
 	}
 	valid, ad, plaintext := decrypt(cs.k, cs.n, ad, ciphertext)
-	cs = setNonce(cs, incrementNonce(cs.n))
+	if valid {
+		cs = setNonce(cs, incrementNonce(cs.n))
+	}
 	return cs, plaintext, valid, err
 }
 

--- a/implementations/go/tests/Npsk0/Npsk0.noise.go
+++ b/implementations/go/tests/Npsk0/Npsk0.noise.go
@@ -240,7 +240,9 @@ func decryptWithAd(cs *cipherstate, ad []byte, ciphertext []byte) (*cipherstate,
 		return cs, []byte{}, false, err
 	}
 	valid, ad, plaintext := decrypt(cs.k, cs.n, ad, ciphertext)
-	cs = setNonce(cs, incrementNonce(cs.n))
+	if valid {
+		cs = setNonce(cs, incrementNonce(cs.n))
+	}
 	return cs, plaintext, valid, err
 }
 

--- a/implementations/go/tests/X/X.noise.go
+++ b/implementations/go/tests/X/X.noise.go
@@ -239,7 +239,9 @@ func decryptWithAd(cs *cipherstate, ad []byte, ciphertext []byte) (*cipherstate,
 		return cs, []byte{}, false, err
 	}
 	valid, ad, plaintext := decrypt(cs.k, cs.n, ad, ciphertext)
-	cs = setNonce(cs, incrementNonce(cs.n))
+	if valid {
+		cs = setNonce(cs, incrementNonce(cs.n))
+	}
 	return cs, plaintext, valid, err
 }
 

--- a/implementations/go/tests/X1K/X1K.noise.go
+++ b/implementations/go/tests/X1K/X1K.noise.go
@@ -244,7 +244,9 @@ func decryptWithAd(cs *cipherstate, ad []byte, ciphertext []byte) (*cipherstate,
 		return cs, []byte{}, false, err
 	}
 	valid, ad, plaintext := decrypt(cs.k, cs.n, ad, ciphertext)
-	cs = setNonce(cs, incrementNonce(cs.n))
+	if valid {
+		cs = setNonce(cs, incrementNonce(cs.n))
+	}
 	return cs, plaintext, valid, err
 }
 

--- a/implementations/go/tests/X1K1/X1K1.noise.go
+++ b/implementations/go/tests/X1K1/X1K1.noise.go
@@ -244,7 +244,9 @@ func decryptWithAd(cs *cipherstate, ad []byte, ciphertext []byte) (*cipherstate,
 		return cs, []byte{}, false, err
 	}
 	valid, ad, plaintext := decrypt(cs.k, cs.n, ad, ciphertext)
-	cs = setNonce(cs, incrementNonce(cs.n))
+	if valid {
+		cs = setNonce(cs, incrementNonce(cs.n))
+	}
 	return cs, plaintext, valid, err
 }
 

--- a/implementations/go/tests/X1N/X1N.noise.go
+++ b/implementations/go/tests/X1N/X1N.noise.go
@@ -242,7 +242,9 @@ func decryptWithAd(cs *cipherstate, ad []byte, ciphertext []byte) (*cipherstate,
 		return cs, []byte{}, false, err
 	}
 	valid, ad, plaintext := decrypt(cs.k, cs.n, ad, ciphertext)
-	cs = setNonce(cs, incrementNonce(cs.n))
+	if valid {
+		cs = setNonce(cs, incrementNonce(cs.n))
+	}
 	return cs, plaintext, valid, err
 }
 

--- a/implementations/go/tests/X1X/X1X.noise.go
+++ b/implementations/go/tests/X1X/X1X.noise.go
@@ -242,7 +242,9 @@ func decryptWithAd(cs *cipherstate, ad []byte, ciphertext []byte) (*cipherstate,
 		return cs, []byte{}, false, err
 	}
 	valid, ad, plaintext := decrypt(cs.k, cs.n, ad, ciphertext)
-	cs = setNonce(cs, incrementNonce(cs.n))
+	if valid {
+		cs = setNonce(cs, incrementNonce(cs.n))
+	}
 	return cs, plaintext, valid, err
 }
 

--- a/implementations/go/tests/X1X1/X1X1.noise.go
+++ b/implementations/go/tests/X1X1/X1X1.noise.go
@@ -242,7 +242,9 @@ func decryptWithAd(cs *cipherstate, ad []byte, ciphertext []byte) (*cipherstate,
 		return cs, []byte{}, false, err
 	}
 	valid, ad, plaintext := decrypt(cs.k, cs.n, ad, ciphertext)
-	cs = setNonce(cs, incrementNonce(cs.n))
+	if valid {
+		cs = setNonce(cs, incrementNonce(cs.n))
+	}
 	return cs, plaintext, valid, err
 }
 

--- a/implementations/go/tests/XK/XK.noise.go
+++ b/implementations/go/tests/XK/XK.noise.go
@@ -243,7 +243,9 @@ func decryptWithAd(cs *cipherstate, ad []byte, ciphertext []byte) (*cipherstate,
 		return cs, []byte{}, false, err
 	}
 	valid, ad, plaintext := decrypt(cs.k, cs.n, ad, ciphertext)
-	cs = setNonce(cs, incrementNonce(cs.n))
+	if valid {
+		cs = setNonce(cs, incrementNonce(cs.n))
+	}
 	return cs, plaintext, valid, err
 }
 

--- a/implementations/go/tests/XK1/XK1.noise.go
+++ b/implementations/go/tests/XK1/XK1.noise.go
@@ -243,7 +243,9 @@ func decryptWithAd(cs *cipherstate, ad []byte, ciphertext []byte) (*cipherstate,
 		return cs, []byte{}, false, err
 	}
 	valid, ad, plaintext := decrypt(cs.k, cs.n, ad, ciphertext)
-	cs = setNonce(cs, incrementNonce(cs.n))
+	if valid {
+		cs = setNonce(cs, incrementNonce(cs.n))
+	}
 	return cs, plaintext, valid, err
 }
 

--- a/implementations/go/tests/XKpsk3/XKpsk3.noise.go
+++ b/implementations/go/tests/XKpsk3/XKpsk3.noise.go
@@ -243,7 +243,9 @@ func decryptWithAd(cs *cipherstate, ad []byte, ciphertext []byte) (*cipherstate,
 		return cs, []byte{}, false, err
 	}
 	valid, ad, plaintext := decrypt(cs.k, cs.n, ad, ciphertext)
-	cs = setNonce(cs, incrementNonce(cs.n))
+	if valid {
+		cs = setNonce(cs, incrementNonce(cs.n))
+	}
 	return cs, plaintext, valid, err
 }
 

--- a/implementations/go/tests/XN/XN.noise.go
+++ b/implementations/go/tests/XN/XN.noise.go
@@ -241,7 +241,9 @@ func decryptWithAd(cs *cipherstate, ad []byte, ciphertext []byte) (*cipherstate,
 		return cs, []byte{}, false, err
 	}
 	valid, ad, plaintext := decrypt(cs.k, cs.n, ad, ciphertext)
-	cs = setNonce(cs, incrementNonce(cs.n))
+	if valid {
+		cs = setNonce(cs, incrementNonce(cs.n))
+	}
 	return cs, plaintext, valid, err
 }
 

--- a/implementations/go/tests/XNpsk3/XNpsk3.noise.go
+++ b/implementations/go/tests/XNpsk3/XNpsk3.noise.go
@@ -241,7 +241,9 @@ func decryptWithAd(cs *cipherstate, ad []byte, ciphertext []byte) (*cipherstate,
 		return cs, []byte{}, false, err
 	}
 	valid, ad, plaintext := decrypt(cs.k, cs.n, ad, ciphertext)
-	cs = setNonce(cs, incrementNonce(cs.n))
+	if valid {
+		cs = setNonce(cs, incrementNonce(cs.n))
+	}
 	return cs, plaintext, valid, err
 }
 

--- a/implementations/go/tests/XX/XX.noise.go
+++ b/implementations/go/tests/XX/XX.noise.go
@@ -241,7 +241,9 @@ func decryptWithAd(cs *cipherstate, ad []byte, ciphertext []byte) (*cipherstate,
 		return cs, []byte{}, false, err
 	}
 	valid, ad, plaintext := decrypt(cs.k, cs.n, ad, ciphertext)
-	cs = setNonce(cs, incrementNonce(cs.n))
+	if valid {
+		cs = setNonce(cs, incrementNonce(cs.n))
+	}
 	return cs, plaintext, valid, err
 }
 

--- a/implementations/go/tests/XX1/XX1.noise.go
+++ b/implementations/go/tests/XX1/XX1.noise.go
@@ -241,7 +241,9 @@ func decryptWithAd(cs *cipherstate, ad []byte, ciphertext []byte) (*cipherstate,
 		return cs, []byte{}, false, err
 	}
 	valid, ad, plaintext := decrypt(cs.k, cs.n, ad, ciphertext)
-	cs = setNonce(cs, incrementNonce(cs.n))
+	if valid {
+		cs = setNonce(cs, incrementNonce(cs.n))
+	}
 	return cs, plaintext, valid, err
 }
 

--- a/implementations/go/tests/XXpsk3/XXpsk3.noise.go
+++ b/implementations/go/tests/XXpsk3/XXpsk3.noise.go
@@ -241,7 +241,9 @@ func decryptWithAd(cs *cipherstate, ad []byte, ciphertext []byte) (*cipherstate,
 		return cs, []byte{}, false, err
 	}
 	valid, ad, plaintext := decrypt(cs.k, cs.n, ad, ciphertext)
-	cs = setNonce(cs, incrementNonce(cs.n))
+	if valid {
+		cs = setNonce(cs, incrementNonce(cs.n))
+	}
 	return cs, plaintext, valid, err
 }
 

--- a/implementations/go/tests/Xpsk1/Xpsk1.noise.go
+++ b/implementations/go/tests/Xpsk1/Xpsk1.noise.go
@@ -240,7 +240,9 @@ func decryptWithAd(cs *cipherstate, ad []byte, ciphertext []byte) (*cipherstate,
 		return cs, []byte{}, false, err
 	}
 	valid, ad, plaintext := decrypt(cs.k, cs.n, ad, ciphertext)
-	cs = setNonce(cs, incrementNonce(cs.n))
+	if valid {
+		cs = setNonce(cs, incrementNonce(cs.n))
+	}
 	return cs, plaintext, valid, err
 }
 

--- a/src/go/5state.go
+++ b/src/go/5state.go
@@ -34,7 +34,9 @@ func decryptWithAd(cs *cipherstate, ad []byte, ciphertext []byte) (*cipherstate,
 		return cs, []byte{}, false, err
 	}
 	valid, ad, plaintext := decrypt(cs.k, cs.n, ad, ciphertext)
-	cs = setNonce(cs, incrementNonce(cs.n))
+	if valid {
+		cs = setNonce(cs, incrementNonce(cs.n))
+	}
 	return cs, plaintext, valid, err
 }
 


### PR DESCRIPTION
Hi!

I noticed an issue in the Go implementation of `decryptWithAd()`: Whenever `decrypt()` reports an authentication failure, the nonce in CipherState is still incremented unconditionally. Doing so will result in all subsequent packets being rejected as their nonces will not match anymore. This might also be abused for DoS attacks.

A similar issue has been reported and fixed in flynn/noise: https://github.com/flynn/noise/security/advisories/GHSA-g9mp-8g3h-3c5c